### PR TITLE
Add basic keybind support to open the coin pouch with a hotkey

### DIFF
--- a/src/main/java/com/shiftthedev/vaultcoinpouch/VaultCoinPouch.java
+++ b/src/main/java/com/shiftthedev/vaultcoinpouch/VaultCoinPouch.java
@@ -4,6 +4,7 @@ import com.mojang.logging.LogUtils;
 import com.shiftthedev.vaultcoinpouch.config.ReloadConfigCommand;
 import com.shiftthedev.vaultcoinpouch.config.ShowConfigCommand;
 import com.shiftthedev.vaultcoinpouch.config.VCPConfig;
+import com.shiftthedev.vaultcoinpouch.utils.KeyBindings;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -13,6 +14,7 @@ import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.InterModComms;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -30,10 +32,10 @@ public class VaultCoinPouch
 
     public VaultCoinPouch()
     {
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::clientSetup);
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::imc);
         MinecraftForge.EVENT_BUS.addListener(EventPriority.NORMAL, this::registerCommand);
-
         DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> MinecraftForge.EVENT_BUS.addListener(EventPriority.NORMAL, this::registerClientCommand));
     }
 
@@ -50,6 +52,10 @@ public class VaultCoinPouch
                         .priority(780)
                         .icon(EMPTY_COIN_POUCH_SLOT)
                         .build());
+    }
+
+    private void clientSetup(final FMLClientSetupEvent event) {
+        KeyBindings.init();
     }
 
     private void registerCommand(RegisterCommandsEvent event)

--- a/src/main/java/com/shiftthedev/vaultcoinpouch/events/ClientEvents.java
+++ b/src/main/java/com/shiftthedev/vaultcoinpouch/events/ClientEvents.java
@@ -1,19 +1,33 @@
 package com.shiftthedev.vaultcoinpouch.events;
 
+import com.shiftthedev.vaultcoinpouch.VCPRegistry;
+import com.shiftthedev.vaultcoinpouch.VaultCoinPouch;
 import com.shiftthedev.vaultcoinpouch.config.VCPConfigScreen;
 import com.shiftthedev.vaultcoinpouch.container.CoinPouchScreen;
+import com.shiftthedev.vaultcoinpouch.network.KeyPressMessage;
+import com.shiftthedev.vaultcoinpouch.utils.KeyBindings;
+import iskallia.vault.init.ModNetwork;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.ConfigGuiHandler;
+import net.minecraftforge.client.event.InputEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.ModLoadingContext;
+import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import top.theillusivec4.curios.api.CuriosApi;
+import top.theillusivec4.curios.api.type.inventory.ICurioStacksHandler;
 
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 
 import static com.shiftthedev.vaultcoinpouch.VCPRegistry.COIN_POUCH_CONTAINER;
@@ -57,4 +71,58 @@ public class ClientEvents
     {
         MenuScreens.register(COIN_POUCH_CONTAINER, CoinPouchScreen::new);
     }
+
+
+
+    @Mod.EventBusSubscriber(modid = VaultCoinPouch.MOD_ID, value = Dist.CLIENT)
+    public static class ClientForge
+    {
+        @SubscribeEvent
+        public static void onKeyInput(InputEvent.KeyInputEvent event)
+        {
+            if (KeyBindings.SHOW_POUCH.consumeClick())
+            {
+                Minecraft minecraft = Minecraft.getInstance();
+                Player player = minecraft.player;
+                if (player == null) return;
+
+                int slot = findSlotMatchingItemIgnoreNBT(player, VCPRegistry.COIN_POUCH);
+                if (slot == -1) return;
+
+                ModNetwork.CHANNEL.sendToServer(new KeyPressMessage(slot));
+
+            }
+
+        }
+        public static int findSlotMatchingItemIgnoreNBT(Player player, Item targetItem) {
+            for (int i = 0; i < player.getInventory().getContainerSize(); i++) {
+                ItemStack stackInSlot = player.getInventory().getItem(i);
+                if (stackInSlot.getItem() == targetItem) return i;
+            }
+
+            AtomicInteger curiosSlot = new AtomicInteger(-1);
+
+            // Check the player's Curios inventory
+            //THIS DOES NOT WORK IN GAME AND I'M NOT SKILLED ENOUGH TO FIGURE OUT WHY. THE CODE RETURNS THE CURIO SLOT, BUT THE GUI ONLY FLICKERS AND CLOSES
+            CuriosApi.getCuriosHelper().getCuriosHandler(player).ifPresent(handler -> {
+                for (Map.Entry<String, ICurioStacksHandler> entry : handler.getCurios().entrySet()) {
+                    String id = entry.getKey();
+                    ICurioStacksHandler stacksHandler = entry.getValue();
+                    for (int i = 0; i < stacksHandler.getSlots(); i++) {
+                        ItemStack stackInSlot = stacksHandler.getStacks().getStackInSlot(i);
+                        if (stackInSlot.getItem() == targetItem) {
+                            // Set the slot index with an offset to differentiate it from the main inventory slots
+                            curiosSlot.set(player.getInventory().getContainerSize() + i);
+                            break;
+                        }
+                    }
+                }
+            });
+
+            return curiosSlot.get();
+        }
+
+    }
+
 }
+

--- a/src/main/java/com/shiftthedev/vaultcoinpouch/mixins/ModNetworkMixin.java
+++ b/src/main/java/com/shiftthedev/vaultcoinpouch/mixins/ModNetworkMixin.java
@@ -1,6 +1,7 @@
 package com.shiftthedev.vaultcoinpouch.mixins;
 
 import com.shiftthedev.vaultcoinpouch.network.ConfigSyncMessage;
+import com.shiftthedev.vaultcoinpouch.network.KeyPressMessage;
 import com.shiftthedev.vaultcoinpouch.network.ShiftVaultForgeRequestCraftMessage;
 import iskallia.vault.init.ModNetwork;
 import net.minecraftforge.network.NetworkDirection;
@@ -27,5 +28,8 @@ public abstract class ModNetworkMixin
         CHANNEL.registerMessage(ModNetwork.nextId(), ShiftVaultForgeRequestCraftMessage.class, ShiftVaultForgeRequestCraftMessage::encode, ShiftVaultForgeRequestCraftMessage::decode, ShiftVaultForgeRequestCraftMessage::handle);
 
         CHANNEL.registerMessage(ModNetwork.nextId(), ConfigSyncMessage.class, ConfigSyncMessage::encode, ConfigSyncMessage::decode, ConfigSyncMessage::handle, Optional.of(NetworkDirection.PLAY_TO_CLIENT));
+
+        CHANNEL.registerMessage(ModNetwork.nextId(), KeyPressMessage.class, KeyPressMessage::encode, KeyPressMessage::decode, KeyPressMessage::handle, Optional.of(NetworkDirection.PLAY_TO_SERVER));
+
     }
 }

--- a/src/main/java/com/shiftthedev/vaultcoinpouch/network/KeyPressMessage.java
+++ b/src/main/java/com/shiftthedev/vaultcoinpouch/network/KeyPressMessage.java
@@ -1,0 +1,45 @@
+package com.shiftthedev.vaultcoinpouch.network;
+
+import com.shiftthedev.vaultcoinpouch.VaultCoinPouch;
+import com.shiftthedev.vaultcoinpouch.item.CoinPouchItem;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.function.Supplier;
+
+public class KeyPressMessage {
+
+    private final int slot;
+
+    public KeyPressMessage(int slot) {
+        this.slot = slot;
+    }
+
+    public int getSlot() {
+        return this.slot;
+    }
+
+    public static void encode(KeyPressMessage message, FriendlyByteBuf buffer) {
+        buffer.writeInt(message.getSlot());
+    }
+
+    public static KeyPressMessage decode(FriendlyByteBuf buffer) {
+        return new KeyPressMessage(buffer.readInt());
+    }
+
+    public static void handle(KeyPressMessage packet, Supplier<NetworkEvent.Context> contextSupplier) {
+        ServerPlayer player = contextSupplier.get().getSender(); // This is the server player
+        contextSupplier.get().enqueueWork(() -> {
+            int slot = packet.getSlot();
+            VaultCoinPouch.LOGGER.info("Key press message received");
+            VaultCoinPouch.LOGGER.info("Slot: " + slot);
+
+            CoinPouchItem.openGUI(contextSupplier.get().getSender(), slot);
+
+        // Handle the key press here using the server player
+        });
+        contextSupplier.get().setPacketHandled(true);
+    }
+
+}

--- a/src/main/java/com/shiftthedev/vaultcoinpouch/utils/KeyBindings.java
+++ b/src/main/java/com/shiftthedev/vaultcoinpouch/utils/KeyBindings.java
@@ -1,0 +1,21 @@
+package com.shiftthedev.vaultcoinpouch.utils;
+
+import com.mojang.blaze3d.platform.InputConstants;
+import net.minecraft.client.KeyMapping;
+import net.minecraftforge.client.ClientRegistry;
+import net.minecraftforge.client.settings.KeyConflictContext;
+import org.lwjgl.glfw.GLFW;
+
+public class KeyBindings {
+
+
+    public static final String KEY_CATEGORY = "key.categories.vaultcoinpouch";
+    public static final String KEY_SHOWPOUCH = "key.vaultcoinpouch.showpouch";
+
+    public static final KeyMapping SHOW_POUCH = new KeyMapping(KEY_SHOWPOUCH, KeyConflictContext.IN_GAME, InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_P, KEY_CATEGORY);
+
+    public static void init() {
+        ClientRegistry.registerKeyBinding(SHOW_POUCH);
+    }
+
+}

--- a/src/main/resources/assets/vaultcoinpouch/lang/en_us.json
+++ b/src/main/resources/assets/vaultcoinpouch/lang/en_us.json
@@ -48,5 +48,9 @@
   "configs.vaultcoinpouch.jewelCuttingStationInteraction.tooltip": "Enable / Disable interaction with §6Jewel§r §6Cutting§r §6Station §rwithout taking coins out of the pouch.",
 
   "configs.vaultcoinpouch.spiritExtractorInteraction.name": "Spirit Extractor: %s",
-  "configs.vaultcoinpouch.spiritExtractorInteraction.tooltip": "Enable / Disable interaction with §6Spirit§r §6Extractor§r §rwithout taking coins out of the pouch."
+  "configs.vaultcoinpouch.spiritExtractorInteraction.tooltip": "Enable / Disable interaction with §6Spirit§r §6Extractor§r §rwithout taking coins out of the pouch.",
+
+  "key.categories.vaultcoinpouch": "Vault Coin Pouch",
+  "key.vaultcoinpouch.showpouch": "Open Coin Pouch"
+
 }


### PR DESCRIPTION
Works only if the pouch is in the main inventory, and unfortunately not if the pouch is in the Curios slots - I'm too dumb to figure this out right now, but it will involve the following:

- Modifying the KeyPressMessage to send an `IsPouchInCuriosSlot` boolean as well
    - you could also just shift the whole inventory check to the server-side, but I'm a fan of minimising the server's workload when possible
- Use the `IsPouchInCuriosSlot` boolean in the `CoinPouchContainer` class and if it is, using the CuriosAPI inventory instead of the main player inventory to handle the `hasPouch()` and `quickMove()` methods. 

Note the debug text in the `KeyPressMessage.handle` method that will need to be removed before publishing!